### PR TITLE
fix the mimetype for the logo

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -153,6 +153,14 @@ def processing_loop(spark_master, input_queue, output_queue, wikieod_file):
 # ---------------------------------------------------------------------
 
 
+class BrandLogo(views.MethodView):
+    """This class returns the brand logo svg content."""
+
+    def get(self):
+        return flask.send_from_directory(
+            'static/img', 'brand-var.svg', mimetype='image/svg+xml')
+
+
 class HTMLContent(views.MethodView):
     """The view class for the root index page."""
 
@@ -239,6 +247,7 @@ def main():
     app = flask.Flask(__name__)
     app.config['SECRET_KEY'] = 'secret!'
     app.add_url_rule('/', view_func=HTMLContent.as_view('html'))
+    app.add_url_rule('/img/brand-var.svg', view_func=BrandLogo.as_view('logo'))
     app.add_url_rule('/predictions',
                      view_func=PredictionAPI.as_view('predictions',
                                                      input_queue))

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -20,7 +20,7 @@
           <span class="icon-bar"></span>
         </button>
         <a class="navbar-brand" href="/">
-          <img src="/static/img/brand-var.svg" alt="Value at Risk Predictor" style="width: 170px;"/>
+          <img src="/img/brand-var.svg" alt="Value at Risk Predictor" style="width: 170px;"/>
         </a>
       </div>
       <div class="collapse navbar-collapse navbar-collapse-1">


### PR DESCRIPTION
Using the default static files implementation does not return the proper
mimetype for the logo which results in errors on some browsers. This
change implements a custom function for returning the logo image.