### PR TITLE
Use Student's T to totally overfit expected stock returns

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask==0.12
 Flask-SocketIO==2.8.2
 gevent==1.2.1
 gevent-websocket==0.9.5
+scipy==0.17.1


### PR DESCRIPTION
This commit changes the simulation to use Student's T instead of a normal distribution.  Specifically:

1. instead of calculating mean and variance, we fit a Student's T distribution to observed stock returns, 
2. each simulation step samples from the appropriate T distribution to determine predicted returns

Note that the worker image must have `scipy` version 0.17.1 installed.